### PR TITLE
Bump ember-cli-htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.10"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes https://github.com/zeppelin/ember-click-outside/issues/3.

This PR bumps:
  - ember-cli-htmlbars to ^1.0.10
  - ember-cli-app-version to ^1.0.0, which uses a recent version of ember-cli-htmlbars