### PR TITLE
Ignore actions when `isDestroying`

### DIFF
--- a/addon/components/click-outside.js
+++ b/addon/components/click-outside.js
@@ -9,6 +9,10 @@ export default Component.extend(ClickOutside, {
   layout,
 
   clickOutside(e) {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     const exceptSelector = this.get('except-selector');
     if (exceptSelector && $(e.target).closest(exceptSelector).length > 0) {
       return;


### PR DESCRIPTION
This issue has been raised by @JoshSmith in the code-corps-ember repo's [user-menu component](https://github.com/code-corps/code-corps-ember/blob/74cc39251949ef66549bc3e44f0d65fbefba3c55/app/components/user-menu.js#L30-L32) when more than 1 tests were running with the error message: `Cannot call 'set' on a destroyed object`.

I was trying hard to reproduce the error in artificial conditions (i.e. in the test suite) but failed miserably. Nonetheless I'm aware of the issue, as I also got bitten by it before. When the same thing happened inside a private repo of one of my clients, I've tried applying the patch and it made the tests pass. So while I'm not a big fan of saying "take my word for it" instead of writing real tests, this looks to be the case. Sorry.