### PR TITLE
Set “cursor: pointer” on body when inserting click-outside component

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ user interaction, usually a click. If the component attached the outside click
 event handler in the same loop, the handler would catch the event and fire the
 callback immediately.
 
+**Note:** If you need to override the `didInsertElement` and/or
+`willDestroyElement` lifecycle hooks, you must make sure to call
+`this._super(...arguments)` in them because the mixin implements them as well.
+
+```js
+export default Component.extend(ClickOutside, {
+  didInsertElement() {
+    this._super(...arguments);
+
+    // Something else you may want to run when the
+    // element in inserted in the DOM
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+
+    // Something else you may want to run when the
+    // element in removed from the DOM
+  }
+});
+```
+
 ## Development
 
 ### Installation

--- a/addon/mixins/click-outside.js
+++ b/addon/mixins/click-outside.js
@@ -9,10 +9,33 @@ const bound = function(fnName) {
     return this.get(fnName).bind(this);
   });
 };
+const supportsTouchEvents = () => {
+  return 'ontouchstart' in window || window.navigator.msMaxTouchPoints;
+};
 
 export default Ember.Mixin.create({
   clickOutside() {},
   clickHandler: bound('outsideClickHandler'),
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    if (!supportsTouchEvents()) {
+      return;
+    }
+
+    $('body').css('cursor', 'pointer');
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+
+    if (!supportsTouchEvents()) {
+      return;
+    }
+
+    $('body').css('cursor', '');
+  },
 
   outsideClickHandler(e) {
     const element = this.get('element');


### PR DESCRIPTION
In the latest iOS (and possibly earlier versions), the `body` element must have `cursor: pointer` in order for its `click` event handlers to be triggered when the user clicks on any of its descendants that isn’t itself bound to at least one `click` event handler.

So, when a component using the `ClickOutside` mixin is inserted, we set `body`’s `cursor` to `pointer` — otherwise iOS doesn’t send the action.

Let me know if there’s anything I should have done differently 😄