### PR TITLE
feat: ignore click on a removed node

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ export default Component.extend(ClickOutside, {
 });
 ```
 
+## Behavior
+
+For every click in the document, `ember-click-outside` will check if the click target is outside of its component, and trigger the provided action/callback if so.
+
+If the click target cannot be found in the document (probably because it has been deleted before `ember-click-outside` detected the click), no action/callback is triggered, since we cannot check if it is inside or outside of the component.
+
 ## Development
 
 ### Installation

--- a/addon/mixins/click-outside.js
+++ b/addon/mixins/click-outside.js
@@ -43,9 +43,16 @@ export default Ember.Mixin.create({
   outsideClickHandler(e) {
     const element = this.get('element');
     const $target = $(e.target);
+
+    // Check if the click target still is in the DOM.
+    // If not, there is no way to know if it was inside the element or not.
+    const isRemoved = $target.length === 0
+      || $.contains(document.documentElement, $target[0]) === false;
+
+    // Check the element is found as a parent of the click target.
     const isInside = $target.closest(element).length === 1;
 
-    if (!isInside) {
+    if (!isRemoved && !isInside) {
       this.clickOutside(e);
     }
   },


### PR DESCRIPTION
Changes:
- prevent clickOutside to be called for a removed element.
   If the click target is invalid or has been removed from the DOM, do not call the `clickOutside` callback since there is no way to know if it was inside or inside the element.
- update README about the "removed target" behavior 

poke @zeppelin 