### PR TITLE
feat: pass the event object to the component action

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ ember install ember-click-outside
 {{/click-outside}}
 ```
 
+```js
+ ...
+  actions: {
+    // Called on click outside
+    someAction(e /* click event object */) {
+
+    },
+  },
+  ...
+```
+
 If you wish to exclude certain elements from counting as outside clicks, use
 the `except-selector` attribute:
 
@@ -31,7 +42,7 @@ the `except-selector` attribute:
 
 **As a mixin**
 
-In fact, this is the actual implementation of the above component...
+In fact, here is a simplified of implementation of the above component...
 
 ```js
 import Ember from 'ember';
@@ -43,8 +54,8 @@ const { next } = Ember.run;
 export default Component.extend(ClickOutside, {
   layout,
 
-  clickOutside() {
-    this.sendAction();
+  clickOutside(e) {
+    this.sendAction(e);
   },
 
   _attachClickOutsideHandler: on('didInsertElement', function() {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export default Component.extend(ClickOutside, {
   layout,
 
   clickOutside(e) {
-    this.sendAction(e);
+    this.get('action')(e);
   },
 
   _attachClickOutsideHandler: on('didInsertElement', function() {

--- a/addon/components/click-outside.js
+++ b/addon/components/click-outside.js
@@ -18,7 +18,7 @@ export default Component.extend(ClickOutside, {
       return;
     }
 
-    this.sendAction();
+    this.sendAction(e);
   },
 
   _attachClickOutsideHandler: on('didInsertElement', function() {

--- a/addon/components/click-outside.js
+++ b/addon/components/click-outside.js
@@ -18,7 +18,10 @@ export default Component.extend(ClickOutside, {
       return;
     }
 
-    this.sendAction(e);
+    let action = this.get('action');
+    if (typeof action !== 'undefined') {
+      action(e);
+    }
   },
 
   _attachClickOutsideHandler: on('didInsertElement', function() {

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -8,10 +8,11 @@ moduleForComponent('click-outside', 'Integration | Component | click outside', {
 });
 
 test('smoke test', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.on('didClickOutside', function() {
+  this.on('didClickOutside', function(e) {
     assert.ok('`didClickOutside` fired only once');
+    assert.equal(e.target.className, 'outside', 'the event object was passed and is correct');
   });
 
   this.render(hbs`
@@ -32,6 +33,20 @@ test('smoke test', function(assert) {
     this.$('.inside').click();
     this.$('.outside').click();
   });
+});
+
+test(`it doesn't throw without an action handler`, function(assert) {
+  assert.expect(0);
+
+  this.render(hbs`
+    <div class="outside">Somewhere, over the rainbow...</div>
+
+    {{#click-outside}}
+      <div class="inside">We're in</div>
+    {{/click-outside}}
+  `);
+
+  this.$('.outside').click();
 });
 
 test('except selector', function(assert) {


### PR DESCRIPTION
@ncoden Could you take a look at it?

The problem was that the first argument to `sendAction` [must be the name of the action](https://emberjs.com/api/ember/2.15/classes/Ember.Component/methods/sendAction?anchor=sendAction). If none provided, Ember will invoke the action from the `action` property, which would be fine if we could do `this.sendAction('action', e)`, but we can't for some reason. Nevertheless, `this.get('action')(e)` works fine, only it has slightly different behavior, because `this.sendAction()` would not throw if the `action` property doesn't exist - so an extra check is required to make it fully backwards-compatible.

Closes #18