### PR TITLE
Avoid cursor:pointer on body when on mobile device

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -21,8 +21,9 @@ export default Mixin.create({
 
   didInsertElement() {
     this._super(...arguments);
-
-    if (!supportsTouchEvents()) {
+    
+    // https://github.com/zeppelin/ember-click-outside/issues/25
+    if (supportsTouchEvents()) {
       return;
     }
 
@@ -32,7 +33,7 @@ export default Mixin.create({
   willDestroyElement() {
     this._super(...arguments);
 
-    if (!supportsTouchEvents()) {
+    if (supportsTouchEvents()) {
       return;
     }
 


### PR DESCRIPTION
See: https://github.com/zeppelin/ember-click-outside/issues/25