### PR TITLE
Fix evented.on path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In fact, here is a simplified of implementation of the above component...
 
 ```js
 import Component from '@ember/component';
-import { on } from '@ember/event/on';
+import { on } from '@ember/object/evented';
 import { next } from '@ember/runloop';
 import ClickOutsideMixin from 'ember-click-outside/mixin';
 


### PR DESCRIPTION
With ember-source 3.0.0 and ember-cli 3.0.4, I get "Uncaught Error: Could not find module `@ember/event/on`"
The [current docs][docs] say `on` should be imported from `@ember/object/evented`.

[docs]: https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fevented/on