### PR TITLE
Fix except-selector not preventing the action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -2,6 +2,10 @@
 import { matches } from './-private/matches-selector';
 
 export function closest(element, selector) {
+  if (matches(element, selector)) {
+    return element;
+  }
+
   while (element.parentNode) {
     element = element.parentNode;
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "^6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -60,9 +60,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       <div class="outside">Somewhere, over the rainbow...</div>
 
       <div class="except-outside">
-        <div>
-          Somewhere, under the rainbow...
-        </div>
+        Somewhere, under the rainbow...
       </div>
 
       {{#click-outside except-selector=".except-outside" action=(action didClickOutside)}}
@@ -77,7 +75,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
     // the action immediately.
     await next(async ()=> {
       await click('.outside');
-      await click('.except-outside div');
+      await click('.except-outside');
     });
   });
 });


### PR DESCRIPTION
Fixes a bug when `except-selector=".foo"` and the click event fired directly on `<div class="foo">...</div>` and the action is still fired.