### PR TITLE
Improve handling for dynamic content

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -50,6 +50,7 @@ export default Mixin.create({
 
   outsideClickHandler(e) {
     const element = get(this, 'element');
+    const event = event || e;
     const path = event.path || (event.composedPath && event.composedPath());
 
     if (path) {

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -50,8 +50,7 @@ export default Mixin.create({
 
   outsideClickHandler(e) {
     const element = get(this, 'element');
-    const event = event || e;
-    const path = event.path || (event.composedPath && event.composedPath());
+    const path = e.path || (e.composedPath && e.composedPath());
 
     if (path) {
       path.includes(element) || this.clickOutside(e);

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -15,15 +15,6 @@ const ios = () => {
   return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 };
 
-const documentOrBodyContains = (element) => {
-  // https://github.com/zeppelin/ember-click-outside/issues/30
-  if (typeof document.contains === 'function') {
-    return document.contains(element);
-  } else {
-    document.body.contains(element);
-  }
-}
-
 export default Mixin.create({
   clickOutside() {},
   clickHandler: bound('outsideClickHandler'),
@@ -49,16 +40,9 @@ export default Mixin.create({
   },
 
   outsideClickHandler(e) {
-    const element = get(this, 'element');
+    const isOnPath = e.path.includes(get(this, 'element'));
 
-    // Check if the click target still is in the DOM.
-    // If not, there is no way to know if it was inside the element or not.
-    const isRemoved = !e.target || !documentOrBodyContains(e.target);
-
-    // Check the element is found as a parent of the click target.
-    const isInside = element === e.target || element.contains(e.target);
-
-    if (!isRemoved && !isInside) {
+    if (!isOnPath) {
       this.clickOutside(e);
     }
   },

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -1,19 +1,19 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
-import { next } from '@ember/runloop';
-import { render, click } from '@ember/test-helpers';
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import hbs from 'htmlbars-inline-precompile'
+import { next } from '@ember/runloop'
+import { render, click } from '@ember/test-helpers'
 
 module('click-outside', 'Integration | Component | click outside', function(hooks) {
-  setupRenderingTest(hooks);
+  setupRenderingTest(hooks)
 
   test('smoke test', async function(assert) {
-    assert.expect(2);
+    assert.expect(2)
 
-    this.set('didClickOutside', (e)=> {
-      assert.ok('`didClickOutside` fired only once');
-      assert.equal(e.target.className, 'outside', 'the event object was passed and is correct');
-    });
+    this.set('didClickOutside', e => {
+      assert.ok('`didClickOutside` fired only once')
+      assert.equal(e.target.className, 'outside', 'the event object was passed and is correct')
+    })
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
@@ -21,22 +21,24 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       {{#click-outside action=(action didClickOutside)}}
         <div class="inside">We're in</div>
       {{/click-outside}}
-    `);
+    `)
 
-    // It's important to fire the actions in the next run loop. Failing to do so
-    // would make the outside click not to fire. The reason for this is more
-    // often than not the component is rendered as a result of some user
-    // interaction, mainly a click. If the component attached the outside click
-    // event handler in the same loop, the handler would catch the event and send
-    // the action immediately.
-    await next(async ()=> {
-      await click('.inside');
-      await click('.outside');
-    });
-  });
+    /*
+      It's important to fire the actions in the next run loop. Failing to do so
+      would make the outside click not to fire. The reason for this is more
+      often than not the component is rendered as a result of some user
+      interaction, mainly a click. If the component attached the outside click
+      event handler in the same loop, the handler would catch the event and send
+      the action immediately.
+    */
+    await next(async () => {
+      await click('.inside')
+      await click('.outside')
+    })
+  })
 
-  test(`it doesn't throw without an action handler`, async function(assert) {
-    assert.expect(0);
+  test(`it doesn't throw without an action handler`, async assert => {
+    assert.expect(0)
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
@@ -44,17 +46,17 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       {{#click-outside}}
         <div class="inside">We're in</div>
       {{/click-outside}}
-    `);
+    `)
 
-    await click('.outside');
-  });
+    await click('.outside')
+  })
 
   test('except selector', async function(assert) {
-    assert.expect(1);
+    assert.expect(1)
 
-    this.set('didClickOutside', ()=> {
-      assert.ok('`didClickOutside` fired only once');
-    });
+    this.set('didClickOutside', () => {
+      assert.ok('`didClickOutside` fired only once')
+    })
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
@@ -65,17 +67,46 @@ module('click-outside', 'Integration | Component | click outside', function(hook
 
       {{#click-outside except-selector=".except-outside" action=(action didClickOutside)}}
       {{/click-outside}}
-    `);
+    `)
 
-    // It's important to fire the actions in the next run loop. Failing to do so
-    // would make the outside click not to fire. The reason for this is more
-    // often than not the component is rendered as a result of some user
-    // interaction, mainly a click. If the component attached the outside click
-    // event handler in the same loop, the handler would catch the event and send
-    // the action immediately.
-    await next(async ()=> {
-      await click('.outside');
-      await click('.except-outside');
-    });
-  });
-});
+    /*
+      It's important to fire the actions in the next run loop. Failing to do so
+      would make the outside click not to fire. The reason for this is more
+      often than not the component is rendered as a result of some user
+      interaction, mainly a click. If the component attached the outside click
+      event handler in the same loop, the handler would catch the event and send
+      the action immediately.
+    */
+    await next(async () => {
+      await click('.outside')
+      await click('.except-outside')
+    })
+  })
+
+  test('handle removed DOM element outside', async function(assert) {
+    assert.expect(1)
+
+    this.set('didClickOutside', () => {
+      assert.ok('`didClickOutside` fired only once')
+    })
+
+    this.set('toggleFlag', () => {
+      this.set('topSide', true)
+    })
+
+    await render(hbs`
+      {{#if topSide}}
+        Blue
+      {{else}}
+        <div class="outside" {{action "toggleFlag"}}>Yellow</div>
+      {{/if}}
+      
+      {{#click-outside action=(action didClickOutside)}}
+      {{/click-outside}}
+    `)
+
+    await next(async () => {
+      await click('.outside')
+    })
+  })
+})

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -17,6 +17,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
+
       {{#click-outside action=(action didClickOutside)}}
         <div class="inside">We're in</div>
       {{/click-outside}}
@@ -39,6 +40,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
+
       {{#click-outside}}
         <div class="inside">We're in</div>
       {{/click-outside}}
@@ -56,9 +58,11 @@ module('click-outside', 'Integration | Component | click outside', function(hook
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
+
       <div class="except-outside">
         Somewhere, under the rainbow...
       </div>
+
       {{#click-outside except-selector=".except-outside" action=(action didClickOutside)}}
       {{/click-outside}}
     `);

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -1,98 +1,90 @@
-import { module, test } from 'qunit'
-import { setupRenderingTest } from 'ember-qunit'
-import hbs from 'htmlbars-inline-precompile'
-import { next } from '@ember/runloop'
-import { render, click } from '@ember/test-helpers'
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { next } from '@ember/runloop';
+import { render, click } from '@ember/test-helpers';
 
 module('click-outside', 'Integration | Component | click outside', function(hooks) {
-  setupRenderingTest(hooks)
+  setupRenderingTest(hooks);
 
   test('smoke test', async function(assert) {
-    assert.expect(2)
+    assert.expect(2);
 
-    this.set('didClickOutside', e => {
-      assert.ok('`didClickOutside` fired only once')
-      assert.equal(e.target.className, 'outside', 'the event object was passed and is correct')
-    })
+    this.set('didClickOutside', (e)=> {
+      assert.ok('`didClickOutside` fired only once');
+      assert.equal(e.target.className, 'outside', 'the event object was passed and is correct');
+    });
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
-
       {{#click-outside action=(action didClickOutside)}}
         <div class="inside">We're in</div>
       {{/click-outside}}
-    `)
+    `);
 
-    /*
-      It's important to fire the actions in the next run loop. Failing to do so
-      would make the outside click not to fire. The reason for this is more
-      often than not the component is rendered as a result of some user
-      interaction, mainly a click. If the component attached the outside click
-      event handler in the same loop, the handler would catch the event and send
-      the action immediately.
-    */
-    await next(async () => {
-      await click('.inside')
-      await click('.outside')
-    })
-  })
+    // It's important to fire the actions in the next run loop. Failing to do so
+    // would make the outside click not to fire. The reason for this is more
+    // often than not the component is rendered as a result of some user
+    // interaction, mainly a click. If the component attached the outside click
+    // event handler in the same loop, the handler would catch the event and send
+    // the action immediately.
+    await next(async ()=> {
+      await click('.inside');
+      await click('.outside');
+    });
+  });
 
-  test(`it doesn't throw without an action handler`, async assert => {
-    assert.expect(0)
+  test(`it doesn't throw without an action handler`, async function(assert) {
+    assert.expect(0);
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
-
       {{#click-outside}}
         <div class="inside">We're in</div>
       {{/click-outside}}
-    `)
+    `);
 
-    await click('.outside')
-  })
+    await click('.outside');
+  });
 
   test('except selector', async function(assert) {
-    assert.expect(1)
+    assert.expect(1);
 
-    this.set('didClickOutside', () => {
-      assert.ok('`didClickOutside` fired only once')
-    })
+    this.set('didClickOutside', ()=> {
+      assert.ok('`didClickOutside` fired only once');
+    });
 
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
-
       <div class="except-outside">
         Somewhere, under the rainbow...
       </div>
-
       {{#click-outside except-selector=".except-outside" action=(action didClickOutside)}}
       {{/click-outside}}
-    `)
+    `);
 
-    /*
-      It's important to fire the actions in the next run loop. Failing to do so
-      would make the outside click not to fire. The reason for this is more
-      often than not the component is rendered as a result of some user
-      interaction, mainly a click. If the component attached the outside click
-      event handler in the same loop, the handler would catch the event and send
-      the action immediately.
-    */
-    await next(async () => {
-      await click('.outside')
-      await click('.except-outside')
-    })
-  })
-
+    // It's important to fire the actions in the next run loop. Failing to do so
+    // would make the outside click not to fire. The reason for this is more
+    // often than not the component is rendered as a result of some user
+    // interaction, mainly a click. If the component attached the outside click
+    // event handler in the same loop, the handler would catch the event and send
+    // the action immediately.
+    await next(async ()=> {
+      await click('.outside');
+      await click('.except-outside');
+    });
+  });
+  
   test('handle removed DOM element outside', async function(assert) {
-    assert.expect(1)
+    assert.expect(1);
 
     this.set('didClickOutside', () => {
-      assert.ok('`didClickOutside` fired only once')
-    })
+      assert.ok('`didClickOutside` fired only once');
+    });
 
     this.set('toggleFlag', () => {
-      this.set('topSide', true)
-    })
+      this.set('topSide', true);
+    });
 
     await render(hbs`
       {{#if topSide}}
@@ -103,10 +95,10 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       
       {{#click-outside action=(action didClickOutside)}}
       {{/click-outside}}
-    `)
+    `);
 
     await next(async () => {
-      await click('.outside')
-    })
-  })
-})
+      await click('.outside');
+    });
+  });
+});


### PR DESCRIPTION
Hi guys, I'm running into issue with dynamic content in ember app. If I have something like:
```
{{#if something}}
  some content
{{else}}
  another content
{{/if}}
```
if on click I change condition it does not work with `click-outside`.
Proposed change fix this issue and improve performance.

If this PR approved then my previous PR #40 has no sense and can be closed.