### PR TITLE
Rename "action" handler to "onClickOutside"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A component and mixin for detecting clicks happened outside the element.
 
-
-## Usage
+## Installation
 
 From within your ember-cli project directory install the addon:
 
@@ -11,18 +10,18 @@ From within your ember-cli project directory install the addon:
 ember install ember-click-outside
 ```
 
-Then:
+## Usage
 
-**As a component**
+### As a component
 
 ```hbs
-{{#click-outside action=(action "someAction")}}
+{{#click-outside onClickOutside=(action "someAction")}}
   Your HTML...
 {{/click-outside}}
 ```
 
 ```js
- ...
+  ...
   actions: {
     // Called on click outside
     someAction(e /* click event object */) {
@@ -36,14 +35,14 @@ If you wish to exclude certain elements from counting as outside clicks, use
 the `except-selector` attribute:
 
 ```hbs
-{{#click-outside action=(action "someAction") except-selector=".some-selector"}}
+{{#click-outside onClickOutside=(action "someAction") except-selector=".some-selector"}}
   Your HTML...
 {{/click-outside}}
 ```
 
-**As a mixin**
+### As a mixin
 
-In fact, here is a simplified of implementation of the above component...
+In fact, here is a simplified version of the implementation of the component above:
 
 ```js
 import Component from '@ember/component';
@@ -52,10 +51,8 @@ import { next } from '@ember/runloop';
 import ClickOutsideMixin from 'ember-click-outside/mixin';
 
 export default Component.extend(ClickOutsideMixin, {
-  layout,
-
   clickOutside(e) {
-    this.get('action')(e);
+    this.get('onClickOutside')(e);
   },
 
   _attachClickOutsideHandler: on('didInsertElement', function() {
@@ -66,7 +63,6 @@ export default Component.extend(ClickOutsideMixin, {
     this.removeClickOutsideListener();
   })
 });
-
 ```
 
 **Note:** You should almost always call `this.addClickOutsideListener` inside
@@ -103,26 +99,3 @@ export default Component.extend(ClickOutsideMixin, {
 For every click in the document, `ember-click-outside` will check if the click target is outside of its component, and trigger the provided action/callback if so.
 
 If the click target cannot be found in the document (probably because it has been deleted before `ember-click-outside` detected the click), no action/callback is triggered, since we cannot check if it is inside or outside of the component.
-
-## Installation
-
-* `git clone <repository-url>` this repository
-* `cd ember-click-outside`
-* `yarn install`
-
-## Running
-
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-
-## Running Tests
-
-* `yarn test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/addon/component.js
+++ b/addon/component.js
@@ -16,17 +16,23 @@ export default Component.extend(ClickOutsideMixin, {
       return;
     }
 
-    // `onClickOutside` handler supersedes the deprecated `action` handler
     let onClickOutside = get(this, 'onClickOutside');
+    let action = get(this, 'action');
+
+    if (typeof onClickOutside === 'function' && typeof action === 'function') {
+      printConsoleMessage(`You've defined both 'onClickOutside' and 'action' handlers. Please use only 'onClickOutside' instead.`);
+    }
+
+    // `onClickOutside` handler supersedes the deprecated `action` handler
     if (typeof onClickOutside === 'function') {
       onClickOutside(e);
 
       return;
     }
 
-    let action = get(this, 'action');
     if (typeof action === 'function') {
       printConsoleMessage(`Using 'action' is deprecated. Please use 'onClickOutside' instead.`);
+
       action(e);
     }
   },

--- a/addon/component.js
+++ b/addon/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { next, cancel } from '@ember/runloop';
 import { closest } from './utils';
 import { get } from '@ember/object';
+import { printConsoleMessage } from '../utils';
 
 export default Component.extend(ClickOutsideMixin, {
 
@@ -16,8 +17,17 @@ export default Component.extend(ClickOutsideMixin, {
       return;
     }
 
+    // `onClickOutside` handler supersedes the deprecated `action` handler
+    let onClickOutside = get(this, 'onClickOutside');
+    if (typeof onClickOutside === 'function') {
+      onClickOutside(e);
+
+      return;
+    }
+
     let action = get(this, 'action');
     if (typeof action === 'function') {
+      printConsoleMessage(`Using 'action' is deprecated. Please use 'onClickOutside' instead.`);
       action(e);
     }
   },

--- a/addon/component.js
+++ b/addon/component.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import { next, cancel } from '@ember/runloop';
 import { closest } from './utils';
 import { get } from '@ember/object';
-import { printConsoleMessage } from '../utils';
+import { printConsoleMessage } from './utils';
 
 export default Component.extend(ClickOutsideMixin, {
 

--- a/addon/component.js
+++ b/addon/component.js
@@ -1,9 +1,8 @@
 import ClickOutsideMixin from './mixin';
 import Component from '@ember/component';
 import { next, cancel } from '@ember/runloop';
-import { closest } from './utils';
+import { closest, printConsoleMessage } from './utils';
 import { get } from '@ember/object';
-import { printConsoleMessage } from './utils';
 
 export default Component.extend(ClickOutsideMixin, {
 

--- a/addon/component.js
+++ b/addon/component.js
@@ -1,39 +1,34 @@
 import ClickOutsideMixin from './mixin';
 import Component from '@ember/component';
 import { next, cancel } from '@ember/runloop';
-import { closest, printConsoleMessage } from './utils';
+import { closest } from './utils';
 import { get } from '@ember/object';
+import { deprecatingAlias } from '@ember/object/computed';
 
 export default Component.extend(ClickOutsideMixin, {
+  'except-selector': deprecatingAlias('exceptSelector', {
+    id: 'ember-click-outside.kebab-cased-props',
+    until: '2.0.0'
+  }),
+
+  action: deprecatingAlias('onClickOutside', {
+    id: 'ember-click-outside.action-prop',
+    until: '2.0.0'
+  }),
 
   clickOutside(e) {
     if (this.isDestroying || this.isDestroyed) {
       return;
     }
 
-    const exceptSelector = get(this, 'except-selector');
+    const exceptSelector = get(this, 'exceptSelector');
     if (exceptSelector && closest(e.target, exceptSelector)) {
       return;
     }
 
     let onClickOutside = get(this, 'onClickOutside');
-    let action = get(this, 'action');
-
-    if (typeof onClickOutside === 'function' && typeof action === 'function') {
-      printConsoleMessage(`You've defined both 'onClickOutside' and 'action' handlers. Please use only 'onClickOutside' instead.`);
-    }
-
-    // `onClickOutside` handler supersedes the deprecated `action` handler
     if (typeof onClickOutside === 'function') {
       onClickOutside(e);
-
-      return;
-    }
-
-    if (typeof action === 'function') {
-      printConsoleMessage(`Using 'action' is deprecated. Please use 'onClickOutside' instead.`);
-
-      action(e);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -63,6 +63,36 @@ module('click-outside', 'Integration | Component | click outside', function(hook
         Somewhere, under the rainbow...
       </div>
 
+      {{#click-outside exceptSelector=".except-outside" onClickOutside=(action didClickOutside)}}
+      {{/click-outside}}
+    `);
+
+    // It's important to fire the actions in the next run loop. Failing to do so
+    // would make the outside click not to fire. The reason for this is more
+    // often than not the component is rendered as a result of some user
+    // interaction, mainly a click. If the component attached the outside click
+    // event handler in the same loop, the handler would catch the event and send
+    // the action immediately.
+    await next(async ()=> {
+      await click('.outside');
+      await click('.except-outside');
+    });
+  });
+
+  test('deprecated `except-selector` still works', async function(assert) {
+    assert.expect(2);
+
+    this.set('didClickOutside', ()=> {
+      assert.ok('`didClickOutside` fired only once');
+    });
+
+    await render(hbs`
+      <div class="outside">Somewhere, over the rainbow...</div>
+
+      <div class="except-outside">
+        Somewhere, under the rainbow...
+      </div>
+
       {{#click-outside except-selector=".except-outside" onClickOutside=(action didClickOutside)}}
       {{/click-outside}}
     `);
@@ -77,6 +107,8 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       await click('.outside');
       await click('.except-outside');
     });
+
+    assert.expectDeprecation();
   });
 
   test('handle removed DOM element outside', async function(assert) {
@@ -106,31 +138,8 @@ module('click-outside', 'Integration | Component | click outside', function(hook
     });
   });
 
-  test('`onClickOutside` handler supersedes `action` handler', async function(assert) {
-    assert.expect(1);
-
-    this.setProperties({
-      action: () => assert.ok('`action` fired once'),
-      onClickOutside: () => assert.ok('`onClickOutside` fired once')
-    });
-
-    await render(hbs`
-      <div class="outside">Somewhere, over the rainbow...</div>
-
-      {{#click-outside onClickOutside=(action onClickOutside) action=(action action)}}
-        <div class="inside">We're in</div>
-      {{/click-outside}}
-    `);
-
-    await next(async ()=> {
-      await click('.inside');
-      await click('.outside');
-    });
-  });
-
-
   test('`action` handler is still valid', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     this.setProperties({
       onClickOutside: () => assert.ok('`onClickOutside` fired once')
@@ -148,5 +157,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       await click('.inside');
       await click('.outside');
     });
+
+    assert.expectDeprecation();
   });
 });

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -127,4 +127,26 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       await click('.outside');
     });
   });
+
+
+  test('`action` handler is still valid', async function(assert) {
+    assert.expect(1);
+
+    this.setProperties({
+      onClickOutside: () => assert.ok('`onClickOutside` fired once')
+    });
+
+    await render(hbs`
+      <div class="outside">Somewhere, over the rainbow...</div>
+
+      {{#click-outside action=(action onClickOutside)}}
+        <div class="inside">We're in</div>
+      {{/click-outside}}
+    `);
+
+    await next(async ()=> {
+      await click('.inside');
+      await click('.outside');
+    });
+  });
 });

--- a/tests/integration/components/click-outside-test.js
+++ b/tests/integration/components/click-outside-test.js
@@ -18,7 +18,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
     await render(hbs`
       <div class="outside">Somewhere, over the rainbow...</div>
 
-      {{#click-outside action=(action didClickOutside)}}
+      {{#click-outside onClickOutside=(action didClickOutside)}}
         <div class="inside">We're in</div>
       {{/click-outside}}
     `);
@@ -35,7 +35,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
     });
   });
 
-  test(`it doesn't throw without an action handler`, async function(assert) {
+  test(`it doesn't throw without an onClickOutside handler`, async function(assert) {
     assert.expect(0);
 
     await render(hbs`
@@ -63,7 +63,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
         Somewhere, under the rainbow...
       </div>
 
-      {{#click-outside except-selector=".except-outside" action=(action didClickOutside)}}
+      {{#click-outside except-selector=".except-outside" onClickOutside=(action didClickOutside)}}
       {{/click-outside}}
     `);
 
@@ -78,7 +78,7 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       await click('.except-outside');
     });
   });
-  
+
   test('handle removed DOM element outside', async function(assert) {
     assert.expect(1);
 
@@ -96,12 +96,34 @@ module('click-outside', 'Integration | Component | click outside', function(hook
       {{else}}
         <div class="outside" {{action "toggleFlag"}}>Yellow</div>
       {{/if}}
-      
-      {{#click-outside action=(action didClickOutside)}}
+
+      {{#click-outside onClickOutside=(action didClickOutside)}}
       {{/click-outside}}
     `);
 
     await next(async () => {
+      await click('.outside');
+    });
+  });
+
+  test('`onClickOutside` handler supersedes `action` handler', async function(assert) {
+    assert.expect(1);
+
+    this.setProperties({
+      action: () => assert.ok('`action` fired once'),
+      onClickOutside: () => assert.ok('`onClickOutside` fired once')
+    });
+
+    await render(hbs`
+      <div class="outside">Somewhere, over the rainbow...</div>
+
+      {{#click-outside onClickOutside=(action onClickOutside) action=(action action)}}
+        <div class="inside">We're in</div>
+      {{/click-outside}}
+    `);
+
+    await next(async ()=> {
+      await click('.inside');
       await click('.outside');
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,6 +103,13 @@ amd-name-resolver@1.0.0:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
+  integrity sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -668,6 +675,13 @@ babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0-beta.6:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-ember-modules-api-polyfill@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.4.2.tgz#e254f8ed0ba7cf32ea6a71c4770b3568a8577402"
@@ -679,6 +693,13 @@ babel-plugin-ember-modules-api-polyfill@^2.3.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
     ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
+  integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
+  dependencies:
+    ember-rfc176-data "^0.3.9"
 
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
@@ -1061,6 +1082,15 @@ babel-polyfill@^6.16.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-env@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.0.tgz#2de1c782a780a0a5d605d199c957596da43c44e4"
@@ -1093,6 +1123,42 @@ babel-preset-env@^1.5.1:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
     browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
 
@@ -1460,6 +1526,22 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.1.2:
     rsvp "^3.5.0"
     workerpool "^2.2.1"
 
+broccoli-babel-transpiler@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
+  integrity sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
+
 broccoli-builder@^0.18.8:
   version "0.18.8"
   resolved "https://registry.yarnpkg.com/broccoli-builder/-/broccoli-builder-0.18.8.tgz#fe54694d544c3cdfdb01028e802eeca65749a879"
@@ -1546,6 +1628,18 @@ broccoli-debug@^0.6.3:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-debug@^0.6.4:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.5.tgz#164a5cdafd8936e525e702bf8f91f39d758e2e78"
+  integrity sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
 broccoli-file-creator@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
@@ -1556,6 +1650,21 @@ broccoli-file-creator@^1.1.1:
     mkdirp "^0.5.1"
     rsvp "~3.0.6"
     symlink-or-copy "^1.0.1"
+
+broccoli-filter@^1.0.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
+  integrity sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    broccoli-plugin "^1.0.0"
+    copy-dereference "^1.0.0"
+    debug "^2.2.0"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rsvp "^3.0.18"
+    symlink-or-copy "^1.0.1"
+    walk-sync "^0.3.1"
 
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
@@ -1805,6 +1914,14 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000710"
     electron-to-chromium "^1.3.17"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
@@ -1915,6 +2032,11 @@ can-symlink@^1.0.0:
 caniuse-lite@^1.0.30000710:
   version "1.0.30000712"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000712.tgz#b4732def2459224f3f78c6a9ba103abfcc705670"
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000988"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz#742f35ec1b8b75b9628d705d7652eea1fef983db"
+  integrity sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2627,6 +2749,11 @@ electron-to-chromium@^1.3.17:
   version "1.3.17"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz#41c13457cc7166c5c15e767ae61d86a8cacdee5d"
 
+electron-to-chromium@^1.3.47:
+  version "1.3.214"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.214.tgz#8b5b9a0415fd41b69c61f694007597cb8c8eb7e8"
+  integrity sha512-SU9yyql6uA0Fc8bWR7sCYNGBtxkC+tQb6UaC7ReaadN42Kx7Ka+dzx3lAIm9Ock+ULEawJuTFcVB2x34uOCg0Q==
+
 ember-cli-babel@^6.0.0-beta.4:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
@@ -2679,6 +2806,25 @@ ember-cli-babel@^6.10.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
+
+ember-cli-babel@^6.9.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
@@ -2864,6 +3010,14 @@ ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
+  integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.0.1.tgz#3e91ef8222811cd0a8d35fd2b10b2478d0594c04"
@@ -2986,6 +3140,14 @@ ember-modules-codemod@^0.2.11:
     glob "^7.1.1"
     jscodeshift "^0.3.29"
 
+ember-qunit-assert-helpers@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.2.tgz#6fec8a33fd0d2c3fb6202f849291a309581727a4"
+  integrity sha512-P5eAqD753+p/qEeBi6OGpl2EzRxx8O9dUnr6HgyxU9fqQsSNQkJNGZ+ajbtePI8oMDGm+X7uOnf1+BgQ7eJ7qg==
+  dependencies:
+    broccoli-filter "^1.0.1"
+    ember-cli-babel "^6.9.0"
+
 ember-qunit@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.2.2.tgz#96c8818ecfa3894580a3dc805f7e7f1e82e07c4a"
@@ -3017,6 +3179,11 @@ ember-rfc176-data@^0.2.0, ember-rfc176-data@^0.2.7:
 ember-rfc176-data@^0.3.0, ember-rfc176-data@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz#6a5a4b8b82ec3af34f3010965fa96b936ca94519"
+
+ember-rfc176-data@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz#44b6e051ead6c044ea87bd551f402e2cf89a7e3d"
+  integrity sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"
@@ -4181,6 +4348,18 @@ hash-for-dep@^1.0.2:
     heimdalljs "^0.2.3"
     heimdalljs-logger "^0.1.7"
     resolve "^1.1.6"
+
+hash-for-dep@^1.2.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.5.1.tgz#497754b39bee2f1c4ade4521bfd2af0a7c1196e3"
+  integrity sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    heimdalljs "^0.2.3"
+    heimdalljs-logger "^0.1.7"
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+    resolve-package-path "^1.0.11"
 
 hawk@3.1.3, hawk@~3.1.0, hawk@~3.1.3:
   version "3.1.3"
@@ -6182,9 +6361,26 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
 path-posix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
+
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
+  dependencies:
+    path-root-regex "^0.1.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -6560,7 +6756,7 @@ regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
@@ -6756,6 +6952,14 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+resolve-package-path@^1.0.11:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.2.7.tgz#2a7bc37ad96865e239330e3102c31322847e652e"
+  integrity sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6771,6 +6975,13 @@ resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.3.3:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.10.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
 
 responselike@1.0.2:
   version "1.0.2"
@@ -6836,6 +7047,11 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
 rsvp@^4.6.1, rsvp@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.7.0.tgz#dc1b0b1a536f7dec9d2be45e0a12ad4197c9fd96"
+
+rsvp@^4.8.2:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 rsvp@~3.0.6:
   version "3.0.21"
@@ -6920,6 +7136,11 @@ semver@^4.3.1:
 semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@~5.1.0:
   version "5.1.1"
@@ -7965,6 +8186,13 @@ wordwrap@~1.0.0:
 workerpool@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.2.2.tgz#1cf53bacafd98ca5d808ff54cc72f3fecb5e1d56"
+  dependencies:
+    object-assign "4.1.1"
+
+workerpool@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.3.tgz#49a70089bd55e890d68cc836a19419451d7c81d7"
+  integrity sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==
   dependencies:
     object-assign "4.1.1"
 


### PR DESCRIPTION
Closes https://github.com/zeppelin/ember-click-outside/issues/45.

I've decided to supersede `onClickOutside`. This means that if `onClickOutside` is passed, `action` is ignored. If both are passed, only `onClickOutside` is called. If only `action` is passed, only `action` is called. 

I've added two deprecation warnings:
1. When both `onClickOutside` and `action` handlers are passed and are functions, it warns that only `onClickOutside` should be defined
2. When only `action` handler is passed, it warns that it's deprecated and `onClickOutside` should be used instead

I've added and adapted the test suite to include the new behaviours, as well as adapting the README.md