### PR TITLE
fix: when exceptSelector is defined and e.target is empty an error is thrown from closest function

### DIFF
--- a/ember-click-outside/src/modifiers/on-click-outside.js
+++ b/ember-click-outside/src/modifiers/on-click-outside.js
@@ -62,7 +62,7 @@ export default class ClickOutsideModifier extends Modifier {
     this.eventHandler = this._createHandler(
       element,
       this.action,
-      this.exceptSelector,
+      this.exceptSelector
     );
     this.cancelOutsideListenerSetup = next(this, this._addClickOutsideListener);
   }

--- a/ember-click-outside/src/modifiers/on-click-outside.js
+++ b/ember-click-outside/src/modifiers/on-click-outside.js
@@ -62,7 +62,7 @@ export default class ClickOutsideModifier extends Modifier {
     this.eventHandler = this._createHandler(
       element,
       this.action,
-      this.exceptSelector
+      this.exceptSelector,
     );
     this.cancelOutsideListenerSetup = next(this, this._addClickOutsideListener);
   }
@@ -88,7 +88,7 @@ export default class ClickOutsideModifier extends Modifier {
 
   _createHandler(element, action, exceptSelector) {
     return (e) => {
-      if (exceptSelector && closest(e.target, exceptSelector)) {
+      if (exceptSelector && e.target && closest(e.target, exceptSelector)) {
         return;
       }
 


### PR DESCRIPTION
Hello,
Thank you very much for your lib :) 
We encounter an error in production, is it possible to merge our contribution to fix the issue.
Indeed when exceptSelector is defined and an event without target is emitted the closest function throws an error. 